### PR TITLE
added optional 'Wire.begin()' disable flag in 'BQ25887::begin()'

### DIFF
--- a/src/BQ25887.cpp
+++ b/src/BQ25887.cpp
@@ -10,9 +10,12 @@ BQ25887::BQ25887(){
 	
 }
 
-bool BQ25887::begin(){
+bool BQ25887::begin(bool wireBegin){
 	
-	Wire.begin();
+	if(wireBegin == true){
+		Wire.begin();
+	}
+	
 	
 	//check PN & DEV if no match return false
 	if(this->readPartInfoReg() != BQ25887_PARTINFO){

--- a/src/BQ25887.h
+++ b/src/BQ25887.h
@@ -90,7 +90,7 @@ class BQ25887{
 	
 	//public methods
 	BQ25887();
-	bool begin();
+	bool begin(bool wireBegin = true);
 	
 	uint8_t readCellVoltageLimitReg();
 	float getCellVoltageLimit();


### PR DESCRIPTION
Added an optional 'Wire.begin()' disable flag in 'BQ25887::begin()' method, as calling 'Wire.begin()' multiple times (when using multiple I2C dependant libraries) may cause conflicts with certain Arduino cores.

'Wire.begin()' call is enabled by default, so no changes to existing implementations are necessary.